### PR TITLE
Fixed the issue when in the logs were errors about  "setState() called after dispose()"

### DIFF
--- a/lib/src/auto_size_text_field.dart
+++ b/lib/src/auto_size_text_field.dart
@@ -593,9 +593,9 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
     super.initState();
 
     widget.controller.addListener(() {
-      this.setState(() {
-
-      });
+      if (this.mounted) {
+        this.setState(() {});
+      }
     });
   }
 


### PR DESCRIPTION
Fixes the warning in the flutter console with the case, when the state haven't yet been initialized, but already called