### PR TITLE
Simple workaround to add the space on the each line in the dynamic width mode, so the last character won't be dropped on the next line

### DIFF
--- a/lib/src/auto_size_text_field.dart
+++ b/lib/src/auto_size_text_field.dart
@@ -764,6 +764,33 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
 
     tp.layout(maxWidth: constraints.maxWidth);
 
+    if (text.text.length > 0) {
+      // replace all \n with 'space with \n' to prevent dropping last character to new line
+      String textWithSpaces = text.text.replaceAll('\n', ' \n');
+      // \n is 10, <space> is 32
+      if (text.text.codeUnitAt(text.text.length - 1) != 10 &&
+          text.text.codeUnitAt(text.text.length - 1) != 32) {
+        textWithSpaces += ' ';
+      }
+      var secondPainter = TextPainter(
+        text: TextSpan(
+          text: textWithSpaces,
+          recognizer: text.recognizer,
+          children: text.children,
+          semanticsLabel: text.semanticsLabel,
+          style: text.style,
+        ),
+        textAlign: widget.textAlign ?? TextAlign.left,
+        textDirection: widget.textDirection ?? TextDirection.ltr,
+        textScaleFactor: scale ?? 1,
+        maxLines: maxLines,
+        locale: widget.locale,
+        strutStyle: widget.strutStyle,
+      );
+      secondPainter.layout(maxWidth: constraints.maxWidth);
+      _textSpanWidth = secondPainter.width;
+    }
+
     _textSpanWidth = math.max(tp.width, widget.minWidth ?? 0);
 
     return !(tp.didExceedMaxLines ||


### PR DESCRIPTION
I have experienced the same issue mentioned here: https://github.com/lzhuor/auto_size_text_field/issues/2
This is pretty simple approach, but this works out (check the gif)
![ezgif-2-2679a4844451](https://user-images.githubusercontent.com/14362650/98908970-da094880-24c9-11eb-9d9a-330f14de426d.gif)
