### PR TITLE
Fixed accessibility size

### DIFF
--- a/lib/src/auto_size_text_field.dart
+++ b/lib/src/auto_size_text_field.dart
@@ -579,7 +579,7 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
     return Container(
       width: widget.fullwidth
           ? double.infinity
-          : math.max(fontSize, _textSpanWidth),
+          : math.max(fontSize, _textSpanWidth * MediaQuery.of(context).textScaleFactor),
       child: TextField(
         key: widget.textFieldKey,
         autocorrect: widget.autocorrect,


### PR DESCRIPTION
## Issue
https://github.com/lzhuor/auto_size_text_field/issues/23

## Problem
On device users with disabilities configure larger texts. The calculation of the field size does not consider this variation.

## Expected
That when typing `123` in the field, with the font increased by up to 400%, all numbers are visible on the screen.

## Before

https://user-images.githubusercontent.com/30198542/127186442-6baa8737-8575-4efa-9d34-2dac219d0aab.mov

## Later

https://user-images.githubusercontent.com/30198542/127187066-aa360367-1485-409b-b102-2546c65f078b.mov


