### PR TITLE
fixed wrapping for scaled text by small font accessibilty

### DIFF
--- a/lib/src/auto_size_text_field.dart
+++ b/lib/src/auto_size_text_field.dart
@@ -561,7 +561,7 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
     return Container(
       width: widget.fullwidth
           ? double.infinity
-          : math.max(fontSize, _textSpanWidth * MediaQuery.of(context).textScaleFactor),
+          : math.max(fontSize, _textSpanWidth),
       child: TextField(
         key: widget.textFieldKey,
         autocorrect: widget.autocorrect,


### PR DESCRIPTION
When the phone has set accessibility for font size as smaller than normal the wrapping was acting strange.
I think the Container width was unnecessarily scaled by text factor since the calculated _textSpanWiidth already accounts for it.
And it fixes the issue.

BEFORE:
https://user-images.githubusercontent.com/5622717/215096079-6e21e310-d789-484b-b655-871c9c02e82c.mov

AFTER
https://user-images.githubusercontent.com/5622717/215096124-b6eb4de5-0050-4746-8d8a-6db543cef6a5.mov

