### PR TITLE
fix: expand SDK constraint to allow development with Dart 3.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.2.4
 homepage: https://github.com/lzhuor/auto_size_text_field
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Problem
`pubspec.yaml` declared `sdk: '>=2.17.0 <3.0.0'`, which prevents contributors from running or modifying the package locally on Dart 3.x / Flutter 3.10+.

The package itself works correctly with Dart 3.x, so this constraint only affects development.

## Fix
Expand the upper bound to `<4.0.0`.

## Impact
No breaking change for end users. 
Only removes an artificial restriction for contributors working on the package locally.

Closes #58