### PR TITLE
fix(example): remove deprecated Android v1 embedding reference

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
         android:label="example"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
## Problem
`example/android/app/src/main/AndroidManifest.xml` still referenced `io.flutter.app.FlutterApplication`, a leftover from the deprecated Android v1 embedding.

## What was already correct
- `MainActivity.kt` already extends `FlutterActivity` (v2 embedding)
- The manifest already declared `flutterEmbedding=2`

So this was the only remaining v1 artifact.

## Fix
Removed the `android:name` attribute from the `<application>` tag.

## Impact
Only affects the `example/` app, zero impact on existing users.

Closes #58