### PR TITLE
fix: replace deprecated textScaleFactor with textScaler

### DIFF
--- a/lib/src/auto_size_text_field.dart
+++ b/lib/src/auto_size_text_field.dart
@@ -624,7 +624,7 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
       recognizer: widget.textSpan?.recognizer,
     );
 
-    var userScale = MediaQuery.textScaleFactorOf(context);
+    var userScale = MediaQuery.textScalerOf(context).scale(1.0);
 
     int left;
     int right;
@@ -699,7 +699,7 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
         ),
         textAlign: widget.textAlign,
         textDirection: widget.textDirection ?? TextDirection.ltr,
-        textScaleFactor: scale,
+        textScaler: TextScaler.linear(scale),
         maxLines: words.length,
         locale: widget.locale,
         strutStyle: widget.strutStyle,
@@ -740,7 +740,7 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
       ),
       textAlign: widget.textAlign,
       textDirection: widget.textDirection ?? TextDirection.ltr,
-      textScaleFactor: scale,
+      textScaler: TextScaler.linear(scale),
       maxLines: maxLines,
       locale: widget.locale,
       strutStyle: widget.strutStyle,

--- a/lib/src/auto_size_text_form_field.dart
+++ b/lib/src/auto_size_text_form_field.dart
@@ -635,7 +635,7 @@ class _AutoSizeTextFormFieldState extends State<AutoSizeTextFormField> {
       recognizer: widget.textSpan?.recognizer,
     );
 
-    var userScale = MediaQuery.textScaleFactorOf(context);
+    var userScale = MediaQuery.textScalerOf(context).scale(1.0);
 
     int left;
     int right;
@@ -714,7 +714,7 @@ class _AutoSizeTextFormFieldState extends State<AutoSizeTextFormField> {
         ),
         textAlign: widget.textAlign,
         textDirection: widget.textDirection ?? TextDirection.ltr,
-        textScaleFactor: scale,
+        textScaler: TextScaler.linear(scale),
         maxLines: words.length,
         locale: widget.locale,
         strutStyle: widget.strutStyle,
@@ -759,7 +759,7 @@ class _AutoSizeTextFormFieldState extends State<AutoSizeTextFormField> {
       ),
       textAlign: widget.textAlign,
       textDirection: widget.textDirection ?? TextDirection.ltr,
-      textScaleFactor: scale,
+      textScaler: TextScaler.linear(scale),
       maxLines: maxLines,
       locale: widget.locale,
       strutStyle: widget.strutStyle,


### PR DESCRIPTION
## Problem
`textScaleFactor` on both `MediaQuery` and `TextPainter` was deprecated in Flutter 3.12, generating warnings on any modern Flutter version.
Affected both `AutoSizeTextField` and `AutoSizeTextFormField`.

## Fix
- `MediaQuery.textScaleFactorOf(context)` ->`MediaQuery.textScalerOf(context).scale(1.0)`
- `TextPainter.textScaleFactor` -> `TextPainter.textScaler: TextScaler.linear(...)`

Applied across all 6 occurrences in both source files.

## Note
`TextScaler` was introduced in Flutter 3.12, consistent with supporting Dart 3.x as fixed in the SDK constraint PR.

## Impact
No behavioral change.
`TextScaler.linear()` preserves the same linear scaling behavior as before.

Closes #58