### PR TITLE
fix: handle null controller to prevent crash on widget creation

### DIFF
--- a/lib/src/auto_size_text_field.dart
+++ b/lib/src/auto_size_text_field.dart
@@ -506,7 +506,7 @@ class AutoSizeTextField extends StatefulWidget {
   /// The text to display.
   ///
   /// This will be null if a [textSpan] is provided instead.
-  String get data => controller!.text;
+  String get data => controller?.text ?? '';
 
   /// {@macro flutter.rendering.editable.selectionEnabled}
   bool get selectionEnabled => enableInteractiveSelection;
@@ -517,6 +517,9 @@ class AutoSizeTextField extends StatefulWidget {
 
 class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
   late double _textSpanWidth;
+  TextEditingController? _internalController;
+
+  TextEditingController get _effectiveController => widget.controller ?? _internalController!;
 
   @override
   Widget build(BuildContext context) {
@@ -552,11 +555,38 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
   void initState() {
     super.initState();
 
-    widget.controller!.addListener(() {
-      if (this.mounted) {
-        this.setState(() {});
+    if (widget.controller == null) {
+      _internalController = TextEditingController();
+    }
+    _effectiveController.addListener(_onTextChanged);
+  }
+
+  @override
+  void didUpdateWidget(AutoSizeTextField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller?.removeListener(_onTextChanged);
+      _internalController?.dispose();
+      _internalController = null;
+
+      if (widget.controller == null) {
+        _internalController = TextEditingController();
       }
-    });
+      _effectiveController.addListener(_onTextChanged);
+    } 
+  }
+
+  @override
+  void dispose() {
+    _effectiveController.removeListener(_onTextChanged);
+    _internalController?.dispose();
+
+    super.dispose();
+  }
+
+  void _onTextChanged() {
+    if (mounted) setState(() {});
   }
 
   Widget _buildTextField(double fontSize, TextStyle style, int? maxLines) {
@@ -569,7 +599,7 @@ class _AutoSizeTextFieldState extends State<AutoSizeTextField> {
         autofocus: widget.autofocus,
         buildCounter: widget.buildCounter,
         contextMenuBuilder: widget.contextMenuBuilder,
-        controller: widget.controller,
+        controller: _effectiveController,
         cursorColor: widget.cursorColor,
         cursorRadius: widget.cursorRadius,
         cursorWidth: widget.cursorWidth,

--- a/lib/src/auto_size_text_form_field.dart
+++ b/lib/src/auto_size_text_form_field.dart
@@ -513,7 +513,7 @@ class AutoSizeTextFormField extends StatefulWidget {
   /// The text to display.
   ///
   /// This will be null if a [textSpan] is provided instead.
-  String get data => controller!.text;
+  String get data => controller?.text ?? '';
 
   /// {@macro flutter.rendering.editable.selectionEnabled}
   bool get selectionEnabled => enableInteractiveSelection;
@@ -524,6 +524,9 @@ class AutoSizeTextFormField extends StatefulWidget {
 
 class _AutoSizeTextFormFieldState extends State<AutoSizeTextFormField> {
   late double _textSpanWidth;
+  TextEditingController? _internalController;
+
+  TextEditingController get _effectiveController => widget.controller ?? _internalController!;
 
   @override
   Widget build(BuildContext context) {
@@ -560,11 +563,38 @@ class _AutoSizeTextFormFieldState extends State<AutoSizeTextFormField> {
   void initState() {
     super.initState();
 
-    widget.controller!.addListener(() {
-      if (this.mounted) {
-        this.setState(() {});
+    if (widget.controller == null) {
+      _internalController = TextEditingController();
+    }
+    _effectiveController.addListener(_onTextChanged);
+  }
+
+  @override
+  void didUpdateWidget(AutoSizeTextFormField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller?.removeListener(_onTextChanged);
+      _internalController?.dispose();
+      _internalController = null;
+
+      if (widget.controller == null) {
+        _internalController = TextEditingController();
       }
-    });
+      _effectiveController.addListener(_onTextChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    _effectiveController.removeListener(_onTextChanged);
+    _internalController?.dispose();
+
+    super.dispose();
+  }
+
+  void _onTextChanged() {
+    if (mounted) setState(() {});
   }
 
   Widget _buildTextField(double fontSize, TextStyle style, int? maxLines) {
@@ -580,7 +610,7 @@ class _AutoSizeTextFormFieldState extends State<AutoSizeTextFormField> {
         autofillHints: widget.autofillHints,
         autofocus: widget.autofocus,
         buildCounter: widget.buildCounter,
-        controller: widget.controller,
+        controller: _effectiveController,
         cursorColor: widget.cursorColor,
         cursorRadius: widget.cursorRadius,
         cursorWidth: widget.cursorWidth,


### PR DESCRIPTION
## Problem
The docs for both `AutoSizeTextField` and `AutoSizeTextFormField` state:

> If null, this widget will create its own TextEditingController.

However, the implementation used `widget.controller!` (forced non-null) in `initState` and in the `data` getter, causing an immediate crash when no controller was provided.

## Fix
- Added `_internalController` created in `initState` when `controller` is null
- Added `_effectiveController` getter to unify access transparently
- Added `didUpdateWidget` to handle controller changes during rebuilds
- Added `dispose()` to clean up the internal controller and avoid memory leaks
- Fixed `data` getter to use `controller?.text ?? ''` instead of `controller!`

Applied to both `AutoSizeTextField` and `AutoSizeTextFormField`.

## Impact
No breaking change. Users already passing a controller are unaffected.
This only makes the documented null behavior actually work.

Closes #58